### PR TITLE
Made work with HTTPS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,4 +17,16 @@ dependencies {
 
 tasks.getByName<Test>("test") {
     useJUnitPlatform()
+    jvmArgs("--add-exports", "java.base/sun.security.x509=ALL-UNNAMED")
+}
+
+tasks {
+
+    compileJava {
+        options.compilerArgs.add("--add-exports=java.base/sun.security.x509=ALL-UNNAMED")
+    }
+
+    compileTestJava {
+        options.compilerArgs.add("--add-exports=java.base/sun.security.x509=ALL-UNNAMED")
+    }
 }


### PR DESCRIPTION
There were several problems with this, which I've rectified in this PR:

1) The reactive client wasn't configured to use WireMock as a proxy - it was picking up the system proxy settings, so was proxying (or not) according to those. Since WireMock was set to run on a random port, these can't have been pointing to it.
2) The client wasn't configured to accept WireMock's signing certificate. I've configured it to accept any certificate in this instance.
3) Since this is Java 17 it's currently necessary to add `--add-exports java.base/sun.security.x509=ALL-UNNAMED` to the compile and run configurations in order for the proxying to work fully.

One issue still remains, which is that the reactive client seems to attempt a CONNECT request to initiate proxying regardless of whether the target is HTTP or HTTPS. I've changed the target URL to HTTPS for now and this works OK, but currently WireMock can't handle CONNECT for tunnelling plain text (I wasn't actually aware there were any clients that did this).